### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,6 +47,8 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/nroconsultingllc/website/security/code-scanning/1](https://github.com/nroconsultingllc/website/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `Dependency Review` job. This block should specify the minimal permissions required for the job to function correctly. Based on the nature of the job, which involves reviewing dependencies, the `contents: read` permission is sufficient. This ensures the job adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
