### PR TITLE
Fix nav menu data-state handling

### DIFF
--- a/src/components/blocks/hero-section-1.tsx
+++ b/src/components/blocks/hero-section-1.tsx
@@ -215,7 +215,7 @@ const HeroHeader = () => {
     return (
         <header>
             <nav
-                data-state={menuState && 'active'}
+                data-state={menuState ? 'active' : undefined}
                 className="fixed z-20 w-full px-2 group">
                 <div className={cn('mx-auto mt-2 max-w-6xl px-6 transition-all duration-300 lg:px-12', isScrolled && 'bg-background/50 max-w-4xl rounded-2xl border backdrop-blur-lg lg:px-5')}>
                     <div className="relative flex flex-wrap items-center justify-between gap-6 py-3 lg:gap-0 lg:py-4">


### PR DESCRIPTION
## Summary
- fix `data-state` attribute when menu is closed

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cfc4fa3c8324849a28dd22baef90